### PR TITLE
Implement dynamic voice discovery and per-call options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The Groq TTS component for Home Assistant makes it possible to use the Groq API 
 - **Chime option** – Useful for announcements on speakers. *(See Devices → Groq TTS → CONFIGURE button)*
 - **User-configurable chime sounds** – Drop your own chime sound into  `config/custom_components/groq_tts/chime` folder (MP3).
 - **Audio normalization option** – Uses more CPU but improves audio clarity on mobile phones and small speakers. *(See Devices → Groq TTS → CONFIGURE button)*
+- **Dynamic voice discovery** – Available models and voices are fetched from the Groq API during setup.
+- **Per-call options** – Voice and normalization can be changed when calling `tts.speak`.
+- **In-memory caching** – Frequently used phrases are cached to reduce API calls.
 
 The integration relies on `ffmpeg` for merging chime sounds and for optional loudness normalization. Ensure `ffmpeg` is installed on the system running Home Assistant.
 

--- a/tests/test_groq_tts.py
+++ b/tests/test_groq_tts.py
@@ -25,6 +25,13 @@ sys.modules["homeassistant.helpers.selector"].selector = lambda x: x
 aiohttp_mod = types.ModuleType("aiohttp_client")
 aiohttp_mod.async_get_clientsession = lambda hass: None
 sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_mod)
+sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
+sys.modules["aiohttp"].ClientSession = object
+vol_mod = types.ModuleType("voluptuous")
+vol_mod.Schema = lambda x: x
+vol_mod.Optional = lambda *args, **kwargs: None
+vol_mod.Required = lambda *args, **kwargs: None
+sys.modules.setdefault("voluptuous", vol_mod)
 exceptions_mod = types.ModuleType("exceptions")
 class _HAError(Exception):
     pass


### PR DESCRIPTION
## Summary
- fetch available voices/models during setup
- allow voice & normalization to be set in `tts.speak`
- reuse session and cache audio in engine
- process audio in-memory with ffmpeg
- update README and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480d78718883268d240dfeb1adfde4