### PR TITLE
Remove dynamic voice fetching and rely on local voice list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Groq TTS component for Home Assistant makes it possible to use the Groq API 
 - **Chime option** – Useful for announcements on speakers. *(See Devices → Groq TTS → CONFIGURE button)*
 - **User-configurable chime sounds** – Drop your own chime sound into  `config/custom_components/groq_tts/chime` folder (MP3).
 - **Audio normalization option** – Uses more CPU but improves audio clarity on mobile phones and small speakers. *(See Devices → Groq TTS → CONFIGURE button)*
-- **Dynamic voice discovery** – Available models and voices are fetched from the Groq API during setup.
+- **Dynamic model discovery** – Available models are fetched from the Groq API during setup; voices are selected from a built-in list.
 - **Per-call options** – Voice and normalization can be changed when calling `tts.speak`.
 - **In-memory caching** – Frequently used phrases are cached to reduce API calls.
 
@@ -28,7 +28,7 @@ visit: (https://console.groq.com/)
 - `playai-tts-arabic`
 
 ### Voices
-The integration discovers available voices automatically. As of now, Groq offers the following options:
+The integration provides the following built-in voice options from Groq:
 
 - `Ahmad-PlayAI`
 - `Amira-PlayAI`

--- a/custom_components/groq_tts/config_flow.py
+++ b/custom_components/groq_tts/config_flow.py
@@ -59,11 +59,10 @@ async def fetch_available(endpoint: str, api_key: str | None = None) -> list[str
     return []
 
 async def get_dynamic_options(api_key: str | None) -> tuple[list[str], list[str]]:
-    """Return lists of models and voices, falling back to constants on error."""
+    """Return a dynamic list of models and the built-in voices."""
     models_endpoint = "https://api.groq.com/openai/v1/models"
-    voices_endpoint = "https://api.groq.com/openai/v1/voices"
     models = await fetch_available(models_endpoint, api_key) or MODELS
-    voices = await fetch_available(voices_endpoint, api_key) or VOICES
+    voices = VOICES
     return models, voices
 
 async def validate_user_input(user_input: dict):


### PR DESCRIPTION
## Summary
- Stop requesting Groq voices endpoint and always use the bundled voice list
- Document that only models are fetched dynamically while voices are predefined

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aacf1acf888326baeead0b0d6e4cdb