### PR TITLE
Fix Groq TTS test patching

### DIFF
--- a/tests/test_groq_tts.py
+++ b/tests/test_groq_tts.py
@@ -101,6 +101,8 @@ class DummyHass:
 async def test_async_get_tts_network_error():
     engine = GroqTTSEngine(None, "voice", "model", "http://example.com")
 
-    with patch("groqtts_engine.async_get_clientsession", return_value=DummySession()):
+    with patch.object(
+        groqtts_engine, "async_get_clientsession", return_value=DummySession()
+    ):
         with pytest.raises(HomeAssistantError):
             await engine.async_get_tts(DummyHass(), "hi")


### PR DESCRIPTION
## Summary
- replace string-based patch with patch.object for async_get_clientsession

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacff484b88326af68b7efd61ede75