### PR TITLE
Add reauth flow, diagnostics, and best-practice updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `custom_components/groq_tts/`: Home Assistant integration source.
+  - `config_flow.py`: UI setup/options logic.
+  - `tts.py`: TTS entity and audio post‑processing (ffmpeg).
+  - `groqtts_engine.py`: Async client for Groq TTS API.
+  - `const.py`: Constants and built‑ins (models, voices).
+  - `chime/`: MP3 assets used for optional chime.
+- `tests/`: Pytest unit tests and stubs.
+- `README.md`, `hacs.json`, `manifest.json`: Integration metadata and docs.
+
+## Build, Test, and Development Commands
+- Run tests: `python -m pytest -q`
+  - Executes unit tests in `tests/` with asyncio support and HA stubs.
+- Lint/format (optional): use your local `ruff`/`black` if preferred; keep diffs minimal.
+- No build step required. For end‑to‑end checks, install in a HA instance per README.
+
+## Coding Style & Naming Conventions
+- Python 3.11+, 4‑space indentation, PEP 8 style.
+- Use type hints; prefer `async`/await for I/O and HA APIs.
+- Filenames and module symbols: `snake_case`; constants in `const.py` are `UPPER_SNAKE_CASE`.
+- Log with `_LOGGER` and avoid logging secrets (API keys, tokens).
+
+## Testing Guidelines
+- Framework: `pytest` with `@pytest.mark.asyncio` for async tests.
+- Add tests under `tests/` named `test_*.py`; functions start with `test_`.
+- Cover: config validation (`config_flow.validate_user_input`), chime option discovery, and network/error paths in `GroqTTSEngine`.
+- Run: `pytest -q` locally; keep tests isolated (use stubs/mocks).
+
+## Commit & Pull Request Guidelines
+- Commits: concise, imperative mood (e.g., "Add dynamic voice selector").
+- PRs must include:
+  - Clear description and rationale; link related issues.
+  - Tests for new logic or bug fixes.
+  - Updates to `README.md` if options/models/usage change.
+  - Screenshots of HA config screens if UI flows change.
+
+## Security & Configuration Tips
+- Do not commit API keys or real endpoints beyond defaults.
+- Network calls must be async and resilient; never block the event loop.
+- When adding assets, place MP3s in `custom_components/groq_tts/chime/`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Groq TTS component for Home Assistant makes it possible to use the Groq API 
 - **Audio normalization option** – Uses more CPU but improves audio clarity on mobile phones and small speakers. *(See Devices → Groq TTS → CONFIGURE button)*
 - **Dynamic model discovery** – Available models are fetched from the Groq API during setup; voices are selected from a built-in list.
 - **Per-call options** – Voice and normalization can be changed when calling `tts.speak`.
-- **In-memory caching** – Frequently used phrases are cached to reduce API calls.
+- **In-memory caching** – Frequently used phrases are cached to reduce API calls. Cache size is configurable in options.
 
 The integration relies on `ffmpeg` for merging chime sounds and for optional loudness normalization. Ensure `ffmpeg` is installed on the system running Home Assistant.
 
@@ -68,6 +68,8 @@ data:
   message: My speech has improved now!
   options:
     chime: true                          # Enable or disable the chime
+    normalize_audio: false               # Enable loudness normalization
+    voice: Arista-PlayAI                 # Override voice for this call
 ```
 
 ## HACS installation (preferred)
@@ -100,3 +102,37 @@ Before you can use the PlayAI TTS models with Groq, you must accept the terms fo
 2. Log in with your Groq account.
 3. Accept the terms for the PlayAI TTS model.
 4. After accepting, you can use the integration and generate speech.
+
+## Options & Behavior
+
+- Chime: Plays a short MP3 before speech. Choose a sound (or add your own to `custom_components/groq_tts/chime/`).
+- Normalize Audio: Applies ffmpeg loudness normalization. Uses more CPU.
+- Voice: Override the default voice per entity or call.
+- Audio Cache Size: LRU cache for audio responses (default: 256). Set to 0 to disable caching.
+
+Changing options takes effect on the next TTS operation. If you change options frequently, consider reloading the integration to ensure all options propagate.
+
+## Reauthentication
+
+If your Groq API key expires or is revoked, the integration will prompt you to reauthenticate. When a 401/403 is received from the API, Home Assistant starts a reauth flow. You’ll be asked to enter a new Groq API key. The integration updates the saved key and reloads automatically.
+
+Where to find it:
+- Settings → Devices & Services → Groq TTS → Reconfigure (or follow the on‑screen prompt)
+
+## Diagnostics
+
+For support, you can download diagnostics for the integration from the device/integration page. Diagnostics include a redacted view of your configuration (API key removed) and useful runtime options (endpoint, model, voice, chime, normalization, cache size). Share diagnostics when reporting bugs to speed up triage.
+
+## Duplicate Prevention
+
+The integration prevents duplicate configuration entries by generating a deterministic unique ID from the combination of the TTS URL and model. If you attempt to add the same pair again, the flow will abort.
+
+## Errors & Troubleshooting
+
+- Invalid URL: The configuration form validates the URL for scheme and host.
+- Required Fields: The form marks missing fields as required.
+- Unknown errors: Reported as "Unexpected error — please try again".
+- Non-audio API responses: The integration rejects non-audio content from the TTS API and logs details.
+- ffmpeg errors: If ffmpeg fails (e.g., missing binary or bad filter), the TTS call returns no audio and logs an error.
+
+Ensure `ffmpeg` is installed and available in PATH on the Home Assistant host if you enable chime or normalization.

--- a/custom_components/groq_tts/__init__.py
+++ b/custom_components/groq_tts/__init__.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 from homeassistant.const import Platform
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+import logging
+
+from .const import UNIQUE_ID
 
 PLATFORMS: list[str] = [Platform.TTS]
 
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up entities."""
-
+    # Reload the entry when options change so updates (like cache size)
+    # take effect immediately without requiring a restart.
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -20,3 +26,27 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update by reloading the entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry data to new format.
+
+    - Move legacy UNIQUE_ID stored in data to entry.unique_id
+    """
+    # If the entry already has a unique_id, nothing to do
+    if entry.unique_id:
+        return True
+
+    # Migrate legacy unique id
+    if isinstance(entry.data, dict) and UNIQUE_ID in entry.data:
+        new_data = dict(entry.data)
+        unique_id = new_data.pop(UNIQUE_ID)
+        _LOGGER.debug("Migrating config entry to set unique_id and clean data")
+        hass.config_entries.async_update_entry(entry, data=new_data, unique_id=unique_id)
+        return True
+
+    return True

--- a/custom_components/groq_tts/config_flow.py
+++ b/custom_components/groq_tts/config_flow.py
@@ -9,10 +9,12 @@ import logging
 import aiohttp
 from urllib.parse import urlparse
 import uuid
+import hashlib
 
 from homeassistant import data_entry_flow
 from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.helpers.selector import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_API_KEY,
@@ -26,6 +28,8 @@ from .const import (
     CONF_CHIME_ENABLE,
     CONF_CHIME_SOUND,
     CONF_NORMALIZE_AUDIO,
+    CONF_CACHE_SIZE,
+    DEFAULT_CACHE_SIZE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,35 +37,35 @@ _LOGGER = logging.getLogger(__name__)
 def generate_entry_id() -> str:
     return str(uuid.uuid4())
 
-async def fetch_available(endpoint: str, api_key: str | None = None) -> list[str]:
+async def fetch_available(hass, endpoint: str, api_key: str | None = None) -> list[str]:
     """Fetch list of items from Groq API endpoint returning JSON data."""
     headers = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(endpoint, headers=headers, timeout=10) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    items = data.get("data") or data
-                    if isinstance(items, list):
-                        names = []
-                        for item in items:
-                            if isinstance(item, dict):
-                                name = item.get("id") or item.get("name")
-                                if name:
-                                    names.append(name)
-                            elif isinstance(item, str):
-                                names.append(item)
-                        return sorted(names)
+        session = async_get_clientsession(hass)
+        async with session.get(endpoint, headers=headers, timeout=10) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                items = data.get("data") or data
+                if isinstance(items, list):
+                    names = []
+                    for item in items:
+                        if isinstance(item, dict):
+                            name = item.get("id") or item.get("name")
+                            if name:
+                                names.append(name)
+                        elif isinstance(item, str):
+                            names.append(item)
+                    return sorted(names)
     except Exception as err:  # pylint: disable=broad-except
         _LOGGER.debug("Error fetching %s: %s", endpoint, err)
     return []
 
-async def get_dynamic_options(api_key: str | None) -> tuple[list[str], list[str]]:
+async def get_dynamic_options(hass, api_key: str | None) -> tuple[list[str], list[str]]:
     """Return a dynamic list of models and the built-in voices."""
     models_endpoint = "https://api.groq.com/openai/v1/models"
-    models = await fetch_available(models_endpoint, api_key) or MODELS
+    models = await fetch_available(hass, models_endpoint, api_key) or MODELS
     voices = VOICES
     return models, voices
 
@@ -70,6 +74,12 @@ async def validate_user_input(user_input: dict):
         raise ValueError("Model is required")
     if user_input.get(CONF_VOICE) is None:
         raise ValueError("Voice is required")
+    url = user_input.get(CONF_URL)
+    if not url:
+        raise ValueError("URL is required")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise ValueError("Invalid URL")
 
 def get_chime_options() -> list[dict[str, str]]:
     """
@@ -117,7 +127,7 @@ class GroqTTSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         errors = {}
-        models, voices = await get_dynamic_options(user_input.get(CONF_API_KEY) if user_input else None)
+        models, voices = await get_dynamic_options(self.hass, user_input.get(CONF_API_KEY) if user_input else None)
         schema = vol.Schema({
             vol.Optional(CONF_API_KEY): str,
             vol.Optional(CONF_URL, default="https://api.groq.com/openai/v1/audio/speech"): str,
@@ -131,29 +141,76 @@ class GroqTTSConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await validate_user_input(user_input)
-                entry_id = generate_entry_id()
-                user_input[UNIQUE_ID] = entry_id
-                await self.async_set_unique_id(entry_id)
-                hostname = urlparse(user_input[CONF_URL]).hostname
+                # Create a deterministic unique_id from URL + model to avoid duplicates
+                url_value = user_input[CONF_URL]
+                model_value = user_input[CONF_MODEL]
+                uid_hash = hashlib.sha1(f"{url_value}|{model_value}".encode("utf-8")).hexdigest()
+                unique_id = f"groq_tts_{uid_hash}"
+                await self.async_set_unique_id(unique_id)
+                # Abort if already configured
+                self._abort_if_unique_id_configured()
+                # Store unique id in data for backward-compat device identifiers
+                user_input[UNIQUE_ID] = unique_id
+                hostname = urlparse(url_value).hostname
                 return self.async_create_entry(
                     title=f"Groq TTS ({hostname}, {user_input[CONF_MODEL]})",
                     data=user_input
                 )
             except data_entry_flow.AbortFlow:
                 return self.async_abort(reason="already_configured")
+            except ValueError as e:
+                msg = str(e)
+                if "Invalid URL" in msg:
+                    errors[CONF_URL] = "invalid_url"
+                elif "URL is required" in msg:
+                    errors[CONF_URL] = "required"
+                elif "Model is required" in msg:
+                    errors[CONF_MODEL] = "required"
+                elif "Voice is required" in msg:
+                    errors[CONF_VOICE] = "required"
+                else:
+                    errors["base"] = "unknown_error"
             except Exception as e:
-                _LOGGER.exception(str(e))
+                _LOGGER.exception("Unexpected error in config flow: %s", e)
                 errors["base"] = "unknown_error"
         return self.async_show_form(
             step_id="user",
             data_schema=schema,
             errors=errors,
-            description_placeholders=user_input,
         )
 
     @staticmethod
     def async_get_options_flow(config_entry):
         return GroqTTSOptionsFlow()
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> data_entry_flow.FlowResult:
+        """Handle reauthentication when credentials are invalid."""
+        # Store the entry we're reauthenticating for use in confirm step
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context.get("entry_id"))
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> data_entry_flow.FlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            api_key = user_input.get(CONF_API_KEY)
+            if not api_key:
+                errors[CONF_API_KEY] = "required"
+            else:
+                # Update only the API key, preserve other data
+                reauth_entry = getattr(self, "_reauth_entry", None)
+                if reauth_entry is None:
+                    return self.async_abort(reason="unknown")
+                new_data = dict(reauth_entry.data)
+                new_data[CONF_API_KEY] = api_key
+                # Abort current flow, update & reload the entry with new credentials
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates=new_data,
+                    reason="reauth_successful",
+                )
+
+        schema = vol.Schema({vol.Required(CONF_API_KEY): str})
+        return self.async_show_form(step_id="reauth_confirm", data_schema=schema, errors=errors)
 
 class GroqTTSOptionsFlow(OptionsFlow):
     """Handle options flow for Groq TTS."""
@@ -162,7 +219,8 @@ class GroqTTSOptionsFlow(OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
         chime_options = await self.hass.async_add_executor_job(get_chime_options)
         models, voices = await get_dynamic_options(
-            self.config_entry.options.get(CONF_API_KEY, self.config_entry.data.get(CONF_API_KEY))
+            self.hass,
+            self.config_entry.options.get(CONF_API_KEY, self.config_entry.data.get(CONF_API_KEY)),
         )
         options_schema = vol.Schema({
             vol.Optional(
@@ -211,5 +269,17 @@ class GroqTTSOptionsFlow(OptionsFlow):
                 CONF_NORMALIZE_AUDIO,
                 default=self.config_entry.options.get(CONF_NORMALIZE_AUDIO, self.config_entry.data.get(CONF_NORMALIZE_AUDIO, False))
             ): selector({"boolean": {}})
+            ,
+            vol.Optional(
+                CONF_CACHE_SIZE,
+                default=self.config_entry.options.get(CONF_CACHE_SIZE, DEFAULT_CACHE_SIZE)
+            ): selector({
+                "number": {
+                    "min": 0,
+                    "max": 4096,
+                    "mode": "box",
+                    "step": 1
+                }
+            })
         })
         return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/groq_tts/const.py
+++ b/custom_components/groq_tts/const.py
@@ -3,6 +3,7 @@ Constants for Groq TTS custom component
 """
 
 DOMAIN = "groq_tts"
+VERSION = "0.1"
 CONF_API_KEY = "api_key"
 CONF_MODEL = "model"
 CONF_VOICE = "voice"
@@ -39,3 +40,5 @@ VOICES = [
 CONF_CHIME_ENABLE = "chime"
 CONF_CHIME_SOUND = "chime_sound"
 CONF_NORMALIZE_AUDIO = "normalize_audio"
+CONF_CACHE_SIZE = "cache_size"
+DEFAULT_CACHE_SIZE = 256

--- a/custom_components/groq_tts/diagnostics.py
+++ b/custom_components/groq_tts/diagnostics.py
@@ -1,0 +1,68 @@
+"""Diagnostics support for Groq TTS.
+
+Provides config entry and device diagnostics with sensitive data redacted.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import (
+    CONF_API_KEY,
+    CONF_CHIME_ENABLE,
+    CONF_CHIME_SOUND,
+    CONF_MODEL,
+    CONF_NORMALIZE_AUDIO,
+    CONF_URL,
+    CONF_VOICE,
+    CONF_CACHE_SIZE,
+)
+
+TO_REDACT = {CONF_API_KEY}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry with secrets redacted."""
+    redacted_data = async_redact_data(dict(entry.data), TO_REDACT)
+    redacted_options = async_redact_data(dict(entry.options), TO_REDACT)
+
+    summary = {
+        "endpoint": redacted_data.get(CONF_URL),
+        "model": redacted_data.get(CONF_MODEL),
+        "voice": redacted_options.get(CONF_VOICE, redacted_data.get(CONF_VOICE)),
+        "chime_enabled": redacted_options.get(CONF_CHIME_ENABLE, False),
+        "chime_sound": redacted_options.get(CONF_CHIME_SOUND),
+        "normalize_audio": redacted_options.get(CONF_NORMALIZE_AUDIO, False),
+        "cache_size": redacted_options.get(CONF_CACHE_SIZE),
+    }
+
+    return {
+        "entry_data": redacted_data,
+        "options": redacted_options,
+        "summary": summary,
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a device.
+
+    This integration exposes a single device per config entry; include the same redacted
+    data with the device identifiers.
+    """
+    data = await async_get_config_entry_diagnostics(hass, entry)
+    data["device"] = {
+        "identifiers": list(device.identifiers),
+        "name": device.name,
+        "manufacturer": device.manufacturer,
+        "model": device.model,
+    }
+    return data
+

--- a/custom_components/groq_tts/groqtts_engine.py
+++ b/custom_components/groq_tts/groqtts_engine.py
@@ -6,12 +6,14 @@ import json
 import logging
 import asyncio
 from urllib.error import HTTPError, URLError
+from collections import OrderedDict
 
 import aiohttp
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from asyncio import CancelledError
 
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ConfigEntryAuthFailed
+from .const import VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,13 +23,14 @@ class AudioResponse:
         self.content = content
 
 class GroqTTSEngine:
-    def __init__(self, api_key: str, voice: str, model: str, url: str):
+    def __init__(self, api_key: str, voice: str, model: str, url: str, cache_max: int | None = None):
         self._api_key = api_key
         self._voice = voice
         self._model = model
         self._url = url
         self._session: aiohttp.ClientSession | None = None
-        self._cache: dict[tuple[str, str], bytes] = {}
+        self._cache: OrderedDict[tuple[str, str], bytes] = OrderedDict()
+        self._cache_max = cache_max if cache_max is not None else 256
 
     async def async_get_tts(self, hass, text: str, voice: str | None = None) -> AudioResponse:
         """Asynchronous TTS request using aiohttp for Groq API."""
@@ -37,14 +40,18 @@ class GroqTTSEngine:
         headers = {"Content-Type": "application/json"}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
-        headers["User-Agent"] = "curl/8.7.1"
+        # Provide a clear, integration-specific user agent with version
+        headers["User-Agent"] = f"homeassistant-groq-tts/{VERSION}"
 
         data = {"model": self._model, "input": text, "voice": voice}
 
         cache_key = (voice, text)
         if cache_key in self._cache:
             _LOGGER.debug("Returning cached audio for %s", cache_key)
-            return AudioResponse(self._cache[cache_key])
+            # Move key to end to mark as recently used
+            content = self._cache.pop(cache_key)
+            self._cache[cache_key] = content
+            return AudioResponse(content)
 
         max_retries = 1
         attempt = 0
@@ -57,16 +64,46 @@ class GroqTTSEngine:
             try:
                 async with session.post(self._url, json=data, headers=headers, timeout=30) as resp:
                     content = await resp.read()
-                    if resp.headers.get("content-type", "").startswith("application/json"):
-                        error_json = json.loads(content.decode("utf-8"))
-                        if "error" in error_json:
+                    ctype = resp.headers.get("content-type", "")
+                    # Treat non-2xx as errors; try to parse JSON body for details
+                    if resp.status < 200 or resp.status >= 300:
+                        if resp.status in (401, 403):
+                            raise ConfigEntryAuthFailed("Authentication failed for Groq TTS API")
+                        try:
+                            if ctype.startswith("application/json"):
+                                payload = json.loads(content.decode("utf-8", errors="ignore"))
+                                detail = payload.get("error") or payload
+                                raise HomeAssistantError(f"Groq API error (HTTP {resp.status}): {detail}")
+                            raise HomeAssistantError(f"Groq API error (HTTP {resp.status})")
+                        except HomeAssistantError:
+                            raise
+                        except Exception:
+                            raise HomeAssistantError(f"Groq API error (HTTP {resp.status})")
+                    # If JSON arrives on 2xx, check for embedded error structure
+                    if ctype.startswith("application/json"):
+                        try:
+                            error_json = json.loads(content.decode("utf-8", errors="ignore"))
+                        except Exception:
+                            error_json = {}
+                        if isinstance(error_json, dict) and "error" in error_json:
                             msg = error_json["error"].get("message", str(error_json["error"]))
                             _LOGGER.error("Groq API error: %s", msg)
                             raise HomeAssistantError(f"Groq API error: {msg}")
+                        # Unexpected JSON with 2xx: treat as error if not explicitly successful
+                        raise HomeAssistantError("Groq API returned JSON but no audio content")
+                    # Guard against unexpected content types on 2xx
+                    if not (ctype.startswith("audio/") or ctype.startswith("application/octet-stream")):
+                        raise HomeAssistantError(f"Unexpected content-type from Groq API: {ctype}")
+                    # Cache successful audio payloads with LRU eviction
                     self._cache[cache_key] = content
+                    if len(self._cache) > self._cache_max:
+                        self._cache.popitem(last=False)
                     return AudioResponse(content)
             except CancelledError:
-                _LOGGER.exception("TTS request cancelled")
+                _LOGGER.debug("TTS request cancelled")
+                raise
+            except ConfigEntryAuthFailed:
+                # Bubble up to trigger reauth flow
                 raise
             except (aiohttp.ClientError, HTTPError, URLError) as net_err:
                 status_code = getattr(net_err, "status", None) or getattr(net_err, "code", None)
@@ -93,8 +130,8 @@ class GroqTTSEngine:
                 raise HomeAssistantError("An unknown error occurred while fetching TTS audio") from exc
 
     def close(self):
-        if self._session and not self._session.closed:
-            asyncio.create_task(self._session.close())
+        # Use HA-managed session; do not close here to avoid impacting other integrations
+        return None
 
     @staticmethod
     def get_supported_langs() -> list:

--- a/custom_components/groq_tts/groqtts_engine.py
+++ b/custom_components/groq_tts/groqtts_engine.py
@@ -1,6 +1,7 @@
 """
 TTS Engine for Groq TTS.
 """
+from __future__ import annotations
 import json
 import logging
 import asyncio

--- a/custom_components/groq_tts/manifest.json
+++ b/custom_components/groq_tts/manifest.json
@@ -7,10 +7,9 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/barneyonline/groq_tts",
+  "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/barneyonline/groq_tts/issues",
-  "requirements": [
-    "aiohttp>=3.9.3"
-  ],
+  "requirements": [],
   "version": "0.1"
 }

--- a/custom_components/groq_tts/strings.json
+++ b/custom_components/groq_tts/strings.json
@@ -10,10 +10,20 @@
           "voice": "Voice",
           "url": "Enter the Groq TTS endpoint."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Groq TTS",
+        "description": "Your credentials are no longer valid. Please enter a new API key.",
+        "data": {
+          "api_key": "Groq API key"
+        }
       }
     },
     "error": {
-      "wrong_api_key": "Invalid API key. Please enter a valid API key."
+      "wrong_api_key": "Invalid API key. Please enter a valid API key.",
+      "invalid_url": "Invalid URL. Please enter a valid URL.",
+      "required": "This field is required.",
+      "unknown_error": "Unexpected error — please try again."
     }
   },
   "options": {
@@ -24,7 +34,8 @@
           "chime": "Enable chime sound prior speech (useful for announcements)",
           "chime_sound": "Chime sound",
           "voice": "Voice",
-          "normalize_audio": "Enable loudness for generated audio (uses more CPU)"
+          "normalize_audio": "Enable loudness for generated audio (uses more CPU)",
+          "cache_size": "Audio cache size (items)"
         }
       }
     }

--- a/tests/test_groq_tts.py
+++ b/tests/test_groq_tts.py
@@ -19,6 +19,7 @@ class _OptionsFlow:
         pass
 config_entries_mod.ConfigFlow = _ConfigFlow
 config_entries_mod.OptionsFlow = _OptionsFlow
+config_entries_mod.ConfigEntry = type("ConfigEntry", (object,), {})
 sys.modules.setdefault("homeassistant.config_entries", config_entries_mod)
 sys.modules.setdefault("homeassistant.helpers.selector", types.ModuleType("selector"))
 sys.modules["homeassistant.helpers.selector"].selector = lambda x: x
@@ -37,6 +38,9 @@ exceptions_mod = types.ModuleType("exceptions")
 class _HAError(Exception):
     pass
 exceptions_mod.HomeAssistantError = _HAError
+class _ConfigEntryAuthFailed(Exception):
+    pass
+exceptions_mod.ConfigEntryAuthFailed = _ConfigEntryAuthFailed
 sys.modules.setdefault("homeassistant.exceptions", exceptions_mod)
 
 from importlib.util import spec_from_file_location, module_from_spec
@@ -49,6 +53,21 @@ pkg_name = "testpkg"
 pkg = types.ModuleType(pkg_name)
 pkg.__path__ = [str(COMP_DIR)]
 sys.modules[pkg_name] = pkg
+
+# Additional stubs required by tts module
+sys.modules.setdefault("homeassistant.components", types.ModuleType("components"))
+tts_mod = types.ModuleType("tts")
+class _TextToSpeechEntity:
+    pass
+tts_mod.TextToSpeechEntity = _TextToSpeechEntity
+sys.modules["homeassistant.components.tts"] = tts_mod
+helpers_entity_mod = types.ModuleType("homeassistant.helpers.entity")
+helpers_entity_mod.generate_entity_id = lambda fmt, base, hass=None: "tts.groq_tts_" + (base or "entity")
+sys.modules["homeassistant.helpers.entity"] = helpers_entity_mod
+sys.modules.setdefault("homeassistant.helpers.entity_platform", types.ModuleType("homeassistant.helpers.entity_platform"))
+sys.modules["homeassistant.helpers.entity_platform"].AddEntitiesCallback = object
+sys.modules.setdefault("homeassistant.core", types.ModuleType("homeassistant.core"))
+sys.modules["homeassistant.core"].HomeAssistant = type("HomeAssistant", (object,), {})
 
 spec_const = spec_from_file_location(f"{pkg_name}.const", COMP_DIR / "const.py")
 const = module_from_spec(spec_const)
@@ -64,10 +83,15 @@ groqtts_engine = module_from_spec(spec_engine)
 spec_engine.loader.exec_module(groqtts_engine)
 sys.modules["groqtts_engine"] = groqtts_engine
 
+spec_tts = spec_from_file_location(f"{pkg_name}.tts", COMP_DIR / "tts.py")
+tts_module = module_from_spec(spec_tts)
+spec_tts.loader.exec_module(tts_module)
+
 validate_user_input = config_flow.validate_user_input
 get_chime_options = config_flow.get_chime_options
 GroqTTSEngine = groqtts_engine.GroqTTSEngine
 HomeAssistantError = groqtts_engine.HomeAssistantError
+GroqTTSEntity = tts_module.GroqTTSEntity
 
 
 @pytest.mark.asyncio
@@ -106,3 +130,98 @@ async def test_async_get_tts_network_error():
     ):
         with pytest.raises(HomeAssistantError):
             await engine.async_get_tts(DummyHass(), "hi")
+
+
+class DummyResponse:
+    def __init__(self, status: int, headers: dict, body: bytes):
+        self.status = status
+        self.headers = headers
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyOkJsonSession:
+    def post(self, *args, **kwargs):
+        headers = {"content-type": "application/json"}
+        body = b"{\"ok\": true}"
+        return DummyResponse(200, headers, body)
+
+
+@pytest.mark.asyncio
+async def test_async_get_tts_non_audio_2xx():
+    engine = GroqTTSEngine(None, "voice", "model", "http://example.com")
+    with patch.object(groqtts_engine, "async_get_clientsession", return_value=DummyOkJsonSession()):
+        with pytest.raises(HomeAssistantError):
+            await engine.async_get_tts(DummyHass(), "hello")
+
+
+class Dummy401Session:
+    def post(self, *args, **kwargs):
+        headers = {"content-type": "text/plain"}
+        body = b"unauthorized"
+        return DummyResponse(401, headers, body)
+
+
+@pytest.mark.asyncio
+async def test_async_get_tts_raises_config_entry_auth_failed_on_401():
+    engine = GroqTTSEngine(None, "voice", "model", "http://example.com")
+    with patch.object(groqtts_engine, "async_get_clientsession", return_value=Dummy401Session()):
+        with pytest.raises(exceptions_mod.ConfigEntryAuthFailed):
+            await engine.async_get_tts(DummyHass(), "hello")
+
+
+class DummyEngine:
+    class _Resp:
+        def __init__(self, content: bytes):
+            self.content = content
+
+    async def async_get_tts(self, hass, text, voice=None):
+        return self._Resp(b"audio-bytes")
+
+
+class DummyConfigEntry:
+    def __init__(self, data: dict, options: dict):
+        self.data = data
+        self.options = options
+        self.unique_id = data.get("unique_id")
+
+
+@pytest.mark.asyncio
+async def test_tts_missing_chime_returns_none():
+    # Setup config with chime enabled to a non-existent file
+    data = {"url": "http://example.com", "model": "playai-tts", "voice": "Arista-PlayAI", "unique_id": "uid"}
+    options = {"chime": True, "chime_sound": "does_not_exist.mp3"}
+    entity = GroqTTSEntity(DummyHass(), DummyConfigEntry(data, options), DummyEngine())
+    ext, payload = await entity.async_get_tts_audio("Hello", "en", options=None)
+    assert ext is None and payload is None
+
+
+class DummyProc:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+
+    async def communicate(self, input=None):  # noqa: A002
+        return b"", b"ffmpeg error"
+
+
+@pytest.mark.asyncio
+async def test_tts_ffmpeg_failure_returns_none(monkeypatch):
+    # Enable normalize so ffmpeg runs without requiring chime file
+    data = {"url": "http://example.com", "model": "playai-tts", "voice": "Arista-PlayAI", "unique_id": "uid"}
+    options = {"normalize_audio": True}
+    entity = GroqTTSEntity(DummyHass(), DummyConfigEntry(data, options), DummyEngine())
+
+    async def fake_exec(*args, **kwargs):  # noqa: ANN001, D401
+        return DummyProc(returncode=1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    ext, payload = await entity.async_get_tts_audio("Hello", "en", options=None)
+    assert ext is None and payload is None


### PR DESCRIPTION
- Introduces reauth flow (401/403 => ConfigEntryAuthFailed) with reauth_confirm form\n- Adds diagnostics with API key redaction and summary (endpoint, model, voice, chime, normalize, cache size)\n- Manifest cleanup: integration_type=service, remove aiohttp\n- Removes manual entity_id; deterministic unique_id; HA session in config flow\n- Options reload listener for immediate cache size changes\n- Engine: strict HTTP/content-type checks, bounded LRU cache\n- TTS: clearer ffmpeg not-found handling\n- README: reauth + diagnostics sections\n- Tests: expanded (8 passing)